### PR TITLE
Fix salesagility#9788 - Database Failures in Subpanels throughout SuiteCRM (MySQL Error)

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -873,7 +873,6 @@ class SugarBean
                     $final_query .= ' UNION ALL ( ' . $tmp_final_query . ' )';
                 } else {
                     $final_query_rows = '(' . $parentbean->create_list_count_query($tmp_final_query, $parameters) . ')';
-                    $final_query = '(' . $tmp_final_query . ')';
                     $first = false;
                 }
             }
@@ -927,7 +926,6 @@ class SugarBean
                     $query = ' UNION ALL ( ' . $query . ' )';
                     $final_query_rows .= " UNION ALL ";
                 } else {
-                    $query = '(' . $query . ')';
                     $first = false;
                 }
                 $query_array = $subquery['query_array'];


### PR DESCRIPTION
Fix Issue [9788](https://github.com/salesagility/SuiteCRM/issues/9788) 

## Description
Changes implemented in MySQL 8.0.31 cause SQL queries that pull data for subpannels to fail.  If the outer ( ) is removed from the query, it will complete normally.

The code that adds the outer ( ) to the query is located on lines 876 and 930 of Suite CRM/data/SugarBean.php.  By removing these lines the query if fixed.
 
876:   $final_query = '(' . $tmp_final_query . ')'; 
 930:   $query = '(' . $query . ')'; '''

## Motivation and Context
If the MySQL environment is updated to MySQL 8.0.31 the subpannels that depend on these SQL queries will fail.

## How To Test
<!--- Please describe in detail how to test your changes. -->
Update MySQL to 8.0.31 on host server
Create Account with linked subpanel data (contacts, opportunities, leads, ect)
Subpanels must have data for the error to occur.
Open Account detail page & suitecrm.log to see error.
Remove specified lines and test

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
